### PR TITLE
Henrikbranch

### DIFF
--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -526,6 +526,14 @@ function compute_covariance_matrix(orbs, Js, Σ_inv, atol, minval, pool::Abstrac
 end
 
 #1-arg Covariance
+"""
+    get_covariance_matrix(M,orbits,sigma)
+    get_covariance_matrix(M,orbits,sigma,Js,sparse=true,atol=1e-5,distributed=true)
+
+Calculate the covariance matrix for the orbits. Use the correlation lengths for the energy, pitch, R and Z provided in sigma.
+If provided, use the pre-calculated Jacobian Js to speed up computation, return a sparse matrix if sparse=true, use atol 
+for the precision in computing the covariance between two orbits and use parallel computation if distributed=true.
+"""
 function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits::Vector, sigma::AbstractVector;
                                Js::Vector{Vector{Float64}} = Vector{Float64}[],
                                sparse::Bool = false, atol::Float64 = 1e-3,
@@ -534,7 +542,7 @@ function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits::Vector, sigma
     n = length(orbits)
     ns = length.(orbits)
     ts = [range(0.0, 1.0, length=nn) for nn in ns]
-    orbs = [OrbitSpline(o) for o in orbits]
+    orbs = [OrbitSpline(o) for o in orbits] # For more info on OrbitSpline, see orbits.jl
 
     if isempty(Js)
         J = Array{Vector{Float64}}(undef, n)
@@ -656,6 +664,14 @@ function compute_covariance_matrix(orbs1, Js1, orbs2, Js2, Σ_inv, atol, minval,
 end
 
 #2-arg Covariance
+"""
+    get_covariance_matrix(M,orbits_1,orbits_2,sigma)
+    get_covariance_matrix(M,orbits_1,orbits_2,sigma,Js_1=J1,Js_2=J2,sparse=true,atol=1e-5,distributed=true)
+
+Calculate the covariance between orbits_1 and orbits_2. The number of rows of the resulting covariance matrix 
+will be equal to length(orbits_1) and the number of columns will be equal to length(orbits_2). If provided, use 
+pre-calculated jacobians. See get_covariance_matrix() #1-arg Covariance for further info.
+"""
 function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits_1::Vector, orbits_2::Vector, sigma::AbstractVector;
                                 Js_1::Vector{Vector{Float64}} = Vector{Float64}[],
                                 Js_2::Vector{Vector{Float64}} = Vector{Float64}[],

--- a/src/covariance.jl
+++ b/src/covariance.jl
@@ -541,7 +541,7 @@ function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits::Vector, sigma
                                batch_size = 0, kwargs...)
     n = length(orbits)
     ns = length.(orbits)
-    ts = [range(0.0, 1.0, length=nn) for nn in ns]
+    
     orbs = [OrbitSpline(o) for o in orbits] # For more info on OrbitSpline, see orbits.jl
 
     if isempty(Js)
@@ -554,6 +554,7 @@ function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits::Vector, sigma
     else
         J = Js
     end
+    ts = [range(0.0, 1.0, length=nn) for nn in length.(J)]
     Jis = [make_jacobian_spline(jj,tt) for (jj, tt) in zip(J,ts)]
 
     Σ_inv = S44(inv(Diagonal(sigma.^2)))
@@ -683,7 +684,7 @@ function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits_1::Vector, orb
 
     n1 = length(orbits_1)
     ns1 = length.(orbits_1)
-    ts1 = [range(0.0, 1.0, length=nn) for nn in ns1]
+    
     orbs1 = [OrbitSpline(o) for o in orbits_1]
 
     if isempty(Js_1)
@@ -696,11 +697,12 @@ function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits_1::Vector, orb
     else
         J1 = Js_1
     end
+    ts1 = [range(0.0, 1.0, length=nn) for nn in length.(J1)]
     Jis1 = [make_jacobian_spline(jj,tt) for (jj, tt) in zip(J1,ts1)]
 
     n2 = length(orbits_2)
     ns2 = length.(orbits_2)
-    ts2 = [range(0.0, 1.0, length=nn) for nn in ns2]
+    
     orbs2 = [OrbitSpline(o) for o in orbits_2]
 
     if isempty(Js_2)
@@ -713,6 +715,7 @@ function get_covariance_matrix(M::AxisymmetricEquilibrium, orbits_1::Vector, orb
     else
         J2 = Js_2
     end
+    ts2 = [range(0.0, 1.0, length=nn) for nn in length.(J2)]
     Jis2 = [make_jacobian_spline(jj,tt) for (jj, tt) in zip(J2,ts2)]
 
     if distributed

--- a/src/fidasim_utils.jl
+++ b/src/fidasim_utils.jl
@@ -1,4 +1,11 @@
 # --- FIDASIMSpectra Helper Functions ---
+"""
+    split_spectra(myFIDASIMSpectra)
+
+Split FIDASIM spectra into many spectra, according to orbit class. Orbit class is
+merely a unique orbit (unique EPR coordinate). The returned array should allow the user to 
+manipulate each array element (spectra) with apply_instrumental! etc.
+"""
 function split_spectra(s::FIDASIMSpectra)
     (length(size(s.fida)) == 2) && (length(size(s.pfida)) == 2) && return s
 
@@ -40,6 +47,11 @@ function Base.hcat(x::Zeros{T,3}...) where T <: Real
     return Zeros(size(x[1])[1],n,size(x[1])[3])
 end
 
+"""
+    merge_spectra(FIDASIMSpectra1,FIDASIMSpectra2,...)
+
+Merge many FIDASIM spectra into one.
+"""
 function merge_spectra(s::FIDASIMSpectra...)
     all(x -> length(size(x.fida)) == length(size(s[1].fida)), s) || error("Incompatible fida sizes")
     all(x -> length(x.lambda) == length(s[1].lambda), s) || error("Incompatible lambda sizes")

--- a/src/fidasim_utils.jl
+++ b/src/fidasim_utils.jl
@@ -186,6 +186,37 @@ function sample_f(f::Array{T,N}, w, x, y, z; n=100) where {T,N}
     return ww, xx, yy, zz
 end
 
+"""
+    sample_f(fr,dvols,energy,pitch,R,Z)
+    sample_f(-||-,n=100_000)
+
+Unlike regular sample_f, take non-equidistant 4D grid-points into consideration.
+"""
+function sample_f(fr::Array{T,N}, dvols::AbstractArray, w, x, y, z; n=100_000) where {T,N}
+
+    inds = sample_array(fr.*dvols,n)
+
+    dw = vcat(abs.(diff(w)),abs(w[end]-w[end-1]))
+    dx = vcat(abs.(diff(x)),abs(x[end]-x[end-1]))
+    dy = vcat(abs.(diff(y)),abs(y[end]-y[end-1]))
+    dz = vcat(abs.(diff(z)),abs(z[end]-z[end-1]))
+
+    r = rand(N,n) .- 0.5
+    xx = zeros(n)
+    yy = zeros(n)
+    zz = zeros(n)
+    ww = zeros(n)
+
+    @inbounds for i=1:n
+        ww[i] = max(w[inds[1,i]] + r[1,i]*dw[inds[1,i]], 0.0)
+        xx[i] = x[inds[2,i]] + r[2,i]*dx[inds[2,i]]
+        yy[i] = y[inds[3,i]] + r[3,i]*dy[inds[3,i]]
+        zz[i] = z[inds[4,i]] + r[4,i]*dz[inds[4,i]]
+    end
+
+    return ww, xx, yy, zz
+end
+
 function fbm2mc(d::FIDASIMGuidingCenterFunction; n=1_000_000)
     fr = d.f .* reshape(d.r,(1,1,length(d.r),1))
 
@@ -195,6 +226,52 @@ function fbm2mc(d::FIDASIMGuidingCenterFunction; n=1_000_000)
     class = fill(1,n)
 
     return FIDASIMGuidingCenterParticles(n,nclass,class,weight,r,z,energy,pitch,d.nfast)
+end
+
+"""
+    fbm2mc(F_ps, equidistant)
+    fbm2mc(-||-, n=100_000)
+
+Unlike regular fbm2mc, take non-equidistant 4D grid-points into consideration if equidistant=false. 
+Assume 4D grid to be rectangular.
+"""
+function fbm2mc(d::FIDASIMGuidingCenterFunction, equidistant::Bool; n=1_000_000)
+
+    fr = d.f .* reshape(d.r,(1,1,length(d.r),1))
+    if equidistant
+        energy, pitch, r, z = sample_f(fr,d.energy,d.pitch,d.r,d.z,n=n)
+    else
+        dvols = get4Dvols(d.energy,d.pitch,d.r,d.z)
+        energy, pitch, r, z = sample_f(fr,dvols,d.energy,d.pitch,d.r,d.z,n=n)
+    end
+
+    weight = fill(d.nfast/n,n)
+    nclass = 1
+    class = fill(1,n)
+
+    return FIDASIMGuidingCenterParticles(n,nclass,class,weight,r,z,energy,pitch,d.nfast)
+end
+
+"""
+    get4DDiffs(E, p, R, Z)
+
+Calculate and return 4D-arrays of the diffs of particle-space coordinates. Assume edge diff to be same as next-to-edge diff.
+"""
+function get4DDiffs(E, p, R, Z)
+    dR = vcat(abs.(diff(R)),abs(R[end]-R[end-1]))
+    dR = reshape(dR,1,1,length(dR),1)
+    dR4D = repeat(dR,length(E),length(p),1,length(Z))
+    dZ = vcat(abs.(diff(Z)),abs(Z[end]-Z[end-1]))
+    dZ = reshape(dZ,1,1,1,length(dZ))
+    dZ4D = repeat(dZ,length(E),length(p),length(R),1)
+    dE = vcat(abs.(diff(E)),abs(E[end]-E[end-1]))
+    dE = reshape(dE,length(dE),1,1,1)
+    dE4D = repeat(dE,1,length(p),length(R),length(Z))
+    dp = vcat(abs.(diff(p)),abs(p[end]-p[end-1]))
+    dp = reshape(dp,1,length(dp),1,1)
+    dp4D = repeat(dp,length(E),1,length(R),length(Z))
+
+    return dE4D, dp4D, dR4D, dZ4D
 end
 
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,3 +1,7 @@
+"""
+
+Struct to represent .h5 spectra produced by FIDASIM.
+"""
 struct FIDASIMSpectra{T<:Real}
     nchan::Int
     nlambda::Int
@@ -13,6 +17,36 @@ struct FIDASIMSpectra{T<:Real}
     pfida::Union{Zeros{T,2},Zeros{T,3},Matrix{T},Array{T,3}}
 end
 
+"""
+    FIDASIMSpectra("path/to/FIDASIM/spectra/file.h5")
+
+Create instance of FIDASIMSpectra struct from .h5 file. The data can then be
+accessed via Julia struct syntax.
+
+# Example
+```julia-repl
+julia> myFIDASIMSpectra = FIDASIMSpectra("path/to/FIDASIM/spectra/file.h5")
+FIDASIMSpectra
+    nchan = 81
+    nlambda = 2000
+
+julia> lambda_array = myFIDASIMSpectra.lambda
+2000-element Array{Float64,1}:
+647.005
+647.015
+647.025
+647.035
+⋮
+
+julia> myfida_data = myFIDASIMSpectra.fida
+2000×81 Array{Float64,2}:
+0.0 0.0 ... 0.0 0.0
+0.0 0.0 ... 0.0 0.0
+⋮   ⋮    ⋮    ⋮   ⋮
+0.0 0.0 ... 0.0 0.0
+0.0 0.0 ... 0.0 0.0
+```
+"""
 function FIDASIMSpectra(fname::String)
     isfile(fname) || error("File does not exist")
 
@@ -167,6 +201,33 @@ function Base.show(io::IO, s::FIDASIMFullOrbitParticles)
     println(io, "  nparticles = $(s.npart)")
 end
 
+"""
+    read_fidasim_distribution("path/to/FIDASIM/distribution/.h5/file")
+
+Read FIDASIM distribution .h5 file. Return FIDASIMGuidingCenterFunction, FIDASIMGuidingCenterParticles
+or FIDASIMFullOrbitParticles depending on dtype variable. The data can then be accessed via Julia struct
+syntax.
+
+# Example
+```julia-repl
+julia> myFIDASIM_distribution = read_fidasim_distribution("path/to/FIDASIM/distribution/.h5/file")
+FIDASIMGuidingCenterFunction
+
+julia> r_array = myFIDASIM_distribution.r
+70-element Array{Float64,1}:
+ 100.0
+ 102.0
+ 104.0
+ 106.0
+ 108.0
+ 110.0
+ 112.0
+ 114.0
+ ⋮
+
+julia> 
+```
+"""
 function read_fidasim_distribution(filename::String)
     isfile(filename) || error("File does not exist")
 
@@ -187,6 +248,17 @@ function read_fidasim_distribution(filename::String)
     return d
 end
 
+"""
+    write_fidasim_distribution(M,orbit_array)
+    write_fidasim_distribution(M,orbit_array,filename="myOrbit_distribution.h35",chunksize=1000)
+
+Write array of orbits (as found in Julia package GuidingCenterOrbits.jl/src/orbit.jl/Orbit) calculated in Julia to an 
+.h5 distribution file which can be used as input to FIDASIM. If the array of orbits is longer than 1000, it is highly 
+recommended to set the chunksize to approx 1000. This will then produce several .h5 distribution files. This is because 
+each distribution file should have a reasonable size to be read by FIDASIM. So if write_fidasim_distribution() creates 
+15 .h5 files for example, you will need to do 15 FIDASIM runs and then combine the 15 output spectras into one. 
+This can be done in numerous ways, taking care due to the likely large file amount of memory required.
+"""
 function write_fidasim_distribution(M::AxisymmetricEquilibrium, orbits::Array; filename="orbits.h5",time=0.0,ntot=1e19,chunksize=0)
 
     if chunksize == 0

--- a/src/orbits.jl
+++ b/src/orbits.jl
@@ -212,7 +212,7 @@ function get_orbel_volume(og::OrbitGrid, equidistant::Bool)
                         # Assume edge orbit-element volume to be same as next-to-edge
                         dRm = abs(og.r[end]-og.r[end-1])
                     else
-                        dRm = abs(og.r[Rmi+1]-og.energy[Rmi])
+                        dRm = abs(og.r[Rmi+1]-og.r[Rmi])
                     end
 
                     dO[Ei, pmi, Rmi] = dE*dpm*dRm

--- a/src/orbits.jl
+++ b/src/orbits.jl
@@ -176,6 +176,103 @@ function segment_orbit_grid(M::AxisymmetricEquilibrium, orbit_grid::OrbitGrid, o
 
 end
 
+"""
+    get_orbel_volume(myOrbitGrid, equidistant)
+
+Get the orbit element volume of this specific orbit-grid. 
+If equidistant=false, then return a 3D array with all the orbit volumes.
+Otherwise, just a scalar.
+"""
+function get_orbel_volume(og::OrbitGrid, equidistant::Bool)
+
+    if equidistant
+        dRm = abs(og.r[2]-og.r[1])
+        dE = abs(og.energy[2]-og.energy[1])
+        dpm = abs(og.pitch[2]-og.pitch[1])
+        dO = dE*dpm*dRm
+        return dO
+    else
+        dO = zeros(length(og.energy), length(og.pitch), length(og.r))
+        for Ei=1:length(og.energy)
+            if Ei==length(og.energy)
+                # Assume edge orbit-element volume to be same as next-to-edge
+                dE = abs(og.energy[end]-og.energy[end-1])
+            else
+                dE = abs(og.energy[Ei+1]-og.energy[Ei])
+            end
+            for pmi=1:length(og.pitch)
+                if pmi==length(og.pitch)
+                    # Assume edge orbit-element volume to be same as next-to-edge
+                    dpm = abs(og.pitch[end]-og.pitch[end-1])
+                else
+                    dpm = abs(og.pitch[pmi+1]-og.pitch[pmi])
+                end
+                for Rmi=1:length(og.r)
+                    if Rmi==length(og.r)
+                        # Assume edge orbit-element volume to be same as next-to-edge
+                        dRm = abs(og.r[end]-og.r[end-1])
+                    else
+                        dRm = abs(og.r[Rmi+1]-og.energy[Rmi])
+                    end
+
+                    dO[Ei, pmi, Rmi] = dE*dpm*dRm
+                end
+            end
+        end
+
+        return dO
+    end
+end
+
+"""
+    get4Dvols(E, p, R, Z)
+
+Calculate the volume of all hyper-voxels pertaining to the 4D grid. Assume the hyper-voxels pertaining to the
+upper-end (edge) grid-points have the same volumes as the hyper-voxels just inside of them. Return a 4D array, containing all the hyper-voxel
+volumes. Let the 4D array have size()=(length(E), length(p), length(R), length(Z)). Assumes a rectangular 4D grid.
+"""
+function get4Dvols(E, p, R, Z)
+
+    # Safety-check to ensure vectors
+    if !(1==length(size(E))==length(size(p))==length(size(R))==length(size(Z)))
+        throw(ArgumentError("Energy, pitch, R, Z inputs are not all vectors. Please correct and re-try."))
+    end
+
+    vols = zeros(length(E), length(p), length(R), length(Z))
+    for Ei=1:length(E)
+        if Ei==length(E)
+            dE = abs(E[end]-E[end-1])
+        else
+            dE = abs(E[Ei+1]-E[Ei])
+        end
+        for pi=1:length(p)
+            if pi==length(p)
+                dp = abs(p[end]-p[end-1])
+            else
+                dp = abs(p[pi+1]-p[pi])
+            end
+            for Ri=1:length(R)
+                if Ri==length(R)
+                    dR = abs(R[end]-R[end-1])
+                else
+                    dR = abs(R[Ri+1]-R[Ri])
+                end
+                for Zi=1:length(Z)
+                    if Zi==length(Z)
+                        dZ = abs(Z[end]-Z[end-1])
+                    else
+                        dZ = abs(Z[Zi+1]-Z[Zi])
+                    end
+
+                    vols[Ei,pi,Ri,Zi] = dE*dp*dR*dZ
+                end
+            end
+        end
+    end
+
+    return vols
+end
+
 function orbit_matrix(M::AxisymmetricEquilibrium, grid::OrbitGrid, energy, pitch, r, z; kwargs...)
     nenergy = length(energy)
     npitch = length(pitch)
@@ -248,6 +345,24 @@ function map_orbits(grid::OrbitGrid, f::Vector)
     end
     dorb = abs((grid.r[2]-grid.r[1])*(grid.energy[2]-grid.energy[1])*(grid.pitch[2]-grid.pitch[1]))
     return [i == 0 ? zero(f[1]) : f[i]/(grid.counts[i]*dorb) for i in grid.orbit_index]
+end
+
+"""
+    map_orbits(og, f, equidistant)
+
+Unlike regular map_orbits, take non-equidistant 3D grid-points into consideration.
+"""
+function map_orbits(grid::OrbitGrid, f::Vector, os_equidistant::Bool)
+    if length(grid.counts) != length(f)
+        throw(ArgumentError("Incompatible sizes"))
+    end
+    dorb = abs((grid.r[2]-grid.r[1])*(grid.energy[2]-grid.energy[1])*(grid.pitch[2]-grid.pitch[1]))
+
+    if os_equidistant
+        return [i == 0 ? zero(f[1]) : f[i]/(grid.counts[i]*dorb) for i in grid.orbit_index]
+    else
+        return [i == 0 ? zero(f[1]) : f[i]/(grid.counts[i]*dorb[i]) for i in grid.orbit_index]
+    end
 end
 
 function orbit_index(grid::OrbitGrid, o::EPRCoordinate; nearest=false)
@@ -390,6 +505,31 @@ end
 function fbm2orbit(M::AxisymmetricEquilibrium,d::FIDASIMGuidingCenterFunction; GCP=GCDeuteron, n=1_000_000, kwargs...)
     dmc = fbm2mc(d,n=n)
     return mc2orbit(M, dmc, GCP; kwargs...)
+end
+
+"""
+    removeBadIndices!(dmc, energy, pitch, R, Z)
+    removeBadIndices!(-||-, verbose=true)
+
+Remove bad samples from the dmc (FIDASIMGuidingCenterParticles). Samples that might have ended up outside of the original
+(E,p,R,Z)-ranges.
+"""
+function removeBadIndices!(dmc, energy, pitch, R, Z; verbose=false)
+    if verbose
+        println("Removing bad samples... ")
+    end
+    bad_indices_E = findall(x-> x<=minimum(energy) || x>=maximum(energy),dmc.energy)
+    bad_indices_p = findall(x-> x<=minimum(pitch) || x>=maximum(pitch),dmc.pitch)
+    bad_indices_R = findall(x-> x<=minimum(R) || x>=maximum(R),dmc.r)
+    bad_indices_Z = findall(x-> x<=minimum(Z) || x>=maximum(Z),dmc.z)
+    bad_indices_tot = sort!(unique(vcat(bad_indices_E,bad_indices_p,bad_indices_R,bad_indices_Z)))
+    deleteat!(dmc.energy,bad_indices_tot)
+    deleteat!(dmc.pitch,bad_indices_tot)
+    deleteat!(dmc.r,bad_indices_tot)
+    deleteat!(dmc.z,bad_indices_tot)
+    deleteat!(dmc.weight,bad_indices_tot)
+    deleteat!(dmc.class,bad_indices_tot)
+    dmc = FIDASIMGuidingCenterParticles(length(dmc.energy), length(unique(dmc.class)), dmc.class, dmc.weight, dmc.r, dmc.z, dmc.energy, dmc.pitch, sum(dmc.weight))
 end
 
 struct OrbitSpline{T<:Function}

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -187,7 +187,10 @@ function eprz_distribution(M::AxisymmetricEquilibrium, OS::OrbitSystem, f::Vecto
     f_eprz = zeros(nenergy,npitch,nr,nz)
 
     if warmstart && isfile(file) && (filesize(file) != 0)
-        @load file f_eprz last_ind
+        progress_file = jldopen(file,false,false,false,IOStream)
+        f_eprz = progress_file["f_eprz"]
+        last_ind = progress_file["last_ind"]
+        close(progress_file)
     else
         last_ind = inds[1]
     end
@@ -227,7 +230,10 @@ function eprz_distribution(M::AxisymmetricEquilibrium, OS::OrbitSystem, f::Vecto
         f_ep[w] .= 0.0
         f_eprz[:,:,i,j] .= f_ep
         if checkpoint
-            @save file f_eprz last_ind
+            progress_file = jldopen(file, true,true,true,IOStream)
+            write(progress_file,"f_eprz",f_eprz)
+            write(progress_file,"last_ind",last_ind)
+            close(progress_file)
         end
         last_ind = I
     end


### PR DESCRIPTION
Added 4D non-equidistant functionality. Often assumes edge elements have same voxel-volumes as next-to-edge. New map_orbits() separate from the rest, and currently redundant/non-usable, since orbit tomography currently requires orbit-space grid to be equidistant.